### PR TITLE
Down with tagging

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,4 +11,9 @@ task :codeclimate do
   sh 'CODECLIMATE_REPO_TOKEN=aaf36ba538c166427e081ca1d282bdd3b564484e42ce2859b8a75e2a582a5755 codeclimate-test-reporter'
 end
 
+task :console do
+  sh 'bundle exec bin/console'
+end
+
+
 task :default => :test

--- a/lib/werewolf/commands/join.rb
+++ b/lib/werewolf/commands/join.rb
@@ -12,6 +12,9 @@ module Werewolf
         # puts "_match['command']:  #{_match['command']}"
         # puts "_match['expression']:  #{_match['expression']}"
         # puts '........'
+
+        slackbot = Werewolf::SlackBot.instance()
+        slackbot.register_user(data.user)
         Game.instance.add_username_to_game(data.user)
       end
     end

--- a/lib/werewolf/game.rb
+++ b/lib/werewolf/game.rb
@@ -37,7 +37,7 @@ module Werewolf
     end
 
 
-    def self.instance()
+    def Game.instance()
       @instance ||= Game.new
     end
 

--- a/lib/werewolf/game.rb
+++ b/lib/werewolf/game.rb
@@ -24,7 +24,7 @@ module Werewolf
       @active_roles = nil
       @time_period_generator = create_time_period_generator
       @time_period, @day_number = @time_period_generator.next
-      @vote_tally = {}
+      @vote_tally = {}      # {'candidate_name' => Set[voter_names]}
       @night_actions = {}   # {'action_name' => lambda}
       @time_remaining_in_round = default_time_remaining_in_round
       @claims = {}

--- a/lib/werewolf/slackbot.rb
+++ b/lib/werewolf/slackbot.rb
@@ -14,12 +14,42 @@ module Werewolf
       wolf: ':wolf:'
     }
 
-    def self.format_role role_name
+
+    def initialize(options = {})
+      super options
+      @slack_users = {}
+      @@instance = self
+    end
+
+
+    def SlackBot.instance()
+      @@instance
+    end
+
+
+    def user(slack_id)
+      @slack_users[slack_id]
+    end
+
+
+    def register_user(slack_id)
+      @slack_users[slack_id] = get_slack_user_info(slack_id)
+    end
+
+
+    def get_slack_user_info(slack_id)
+      response = client.web_client.users_info(user: slack_id)
+      response.user
+    end
+
+
+    def SlackBot.format_role role_name
       role_key = role_name.to_sym
       raise InvalidRoleError.new("#{role_name} is not a valid role") unless ROLE_ICONS.has_key? role_key
 
       "#{ROLE_ICONS.fetch role_key} #{role_name}"
     end
+
 
     # This receives notifications from a Game instance upon changes.
     # Game is Observable, and the slackbot is an observer.
@@ -293,7 +323,12 @@ MESSAGE
       elsif player.bot?
         player.name
       else
-        "<@#{player.name}>"
+        slack_user = @slack_users[player.name]
+        if slack_user
+          slack_user.name
+        else 
+          "<@#{player.name}>"
+        end
       end
     end
 

--- a/lib/werewolf/slackbot.rb
+++ b/lib/werewolf/slackbot.rb
@@ -118,9 +118,9 @@ TITLE
       if vote_hash.empty?
         message = "No votes yet :zero:"
       else
-        lines = vote_hash.map do |k, v|
-          voters = v.map{|name| "<@#{name}>"}.join(', ')
-          "Lynch <@#{k}>:  (#{pluralize_votes(v.size)}) - #{voters}"
+        lines = vote_hash.map do |candidate, voterset|
+          voters = voterset.map{|name| "#{get_name(name)}"}.join(', ')
+          "Lynch #{get_name(candidate)}:  (#{pluralize_votes(voterset.size)}) - #{voters}"
         end
         message = lines.join("\n")
       end
@@ -323,12 +323,22 @@ MESSAGE
       elsif player.bot?
         player.name
       else
-        slack_user = @slack_users[player.name]
+        slack_user = user(player.name)
         if slack_user
           slack_user.name
         else 
           "<@#{player.name}>"
         end
+      end
+    end
+
+
+    def get_name(slack_id)
+      slack_user = user(slack_id)
+      if slack_user
+        slack_user.name
+      else 
+        slack_id
       end
     end
 

--- a/test/werewolf/slackbot_test.rb
+++ b/test/werewolf/slackbot_test.rb
@@ -456,9 +456,12 @@ MESSAGE
     def test_handle_tally
       slackbot = Werewolf::SlackBot.new
       expected =
-        "Lynch <@tom>:  (2 votes) - <@seth>, <@bill>\n" \
-        "Lynch <@bill>:  (1 vote) - <@tom>"
+        "Lynch tomx:  (2 votes) - sethx, billx\n" \
+        "Lynch billx:  (1 vote) - tomx"
 
+      slackbot.expects(:user).once.with('seth').returns(stub(:name => 'sethx'))
+      slackbot.expects(:user).twice.with('tom').returns(stub(:name => 'tomx'))
+      slackbot.expects(:user).twice.with('bill').returns(stub(:name => 'billx'))
       slackbot.expects(:tell_all).once.with(expected)
 
       slackbot.handle_tally( {
@@ -621,7 +624,7 @@ MESSAGE
       mock_slack_user = mock('slack_user')
       mock_slack_user.stubs(:name).returns('Lancelot')
       slackbot.stubs(:get_slack_user_info).returns(mock_slack_user)
-      
+
       slackbot.register_user('my_slack_id')
       assert_equal 'Lancelot', slackbot.slackify(Player.new(:name => 'my_slack_id'))
     end
@@ -666,6 +669,24 @@ MESSAGE
       mock_response.expects(:user).returns(mock_user)
 
       slackbot.register_user('foo')
+    end
+
+
+    def test_get_name_with_unregistered_slack_id
+      slackbot = Werewolf::SlackBot.new
+      assert_equal 'foo', slackbot.get_name('foo')
+    end
+
+
+    def test_get_name_with_registered_slack_id
+      slackbot = Werewolf::SlackBot.new
+      slack_id = 'foo'
+      fake_slack_name = 'bar'
+      fake_user_info = stub(:name => fake_slack_name)
+      slackbot.stubs(:get_slack_user_info).returns(fake_user_info)
+      slackbot.register_user(slack_id)
+
+      assert_equal fake_slack_name, slackbot.get_name('foo')
     end
 
   end

--- a/test/werewolf/slackbot_test.rb
+++ b/test/werewolf/slackbot_test.rb
@@ -615,5 +615,58 @@ MESSAGE
       assert_equal '', slackbot.slackify(nil)
     end
 
+
+    def test_slackify_with_slack_user
+      slackbot = Werewolf::SlackBot.new
+      mock_slack_user = mock('slack_user')
+      mock_slack_user.stubs(:name).returns('Lancelot')
+      slackbot.stubs(:get_slack_user_info).returns(mock_slack_user)
+      
+      slackbot.register_user('my_slack_id')
+      assert_equal 'Lancelot', slackbot.slackify(Player.new(:name => 'my_slack_id'))
+    end
+
+
+    def test_singleton_with_no_args_constructor
+      slackbot = Werewolf::SlackBot.new
+      assert_equal slackbot, Werewolf::SlackBot.instance
+    end
+
+
+    def test_singleton_passing_args_to_constructor
+      slackbot = Werewolf::SlackBot.new(token: ENV['SLACK_API_TOKEN'], aliases: ['!', 'w'])
+      assert_equal slackbot, Werewolf::SlackBot.instance
+    end
+
+
+    def test_register_user_calls_get_slack_user_info
+      slackbot = Werewolf::SlackBot.new
+      slackbot.expects(:get_slack_user_info)
+      slackbot.register_user('foo')
+    end
+
+
+    def test_user_returns_what_get_slack_user_info_returned
+      slackbot = Werewolf::SlackBot.new
+      slack_id = 'foo'
+      fake_user_info = 'bar'
+      slackbot.stubs(:get_slack_user_info).returns(fake_user_info)
+      slackbot.register_user(slack_id)
+      assert_equal fake_user_info, slackbot.user(slack_id)
+    end
+
+
+    def test_get_slack_user_info
+      slackbot = Werewolf::SlackBot.new
+
+      # hot mess of things we have no business mocking
+      mock_response = mock('response')
+      mock_user = mock('fun user users_info')
+      slackbot.send(:client).web_client.expects(:users_info).returns(mock_response)
+      mock_response.expects(:user).returns(mock_user)
+
+      slackbot.register_user('foo')
+    end
+
   end
 end


### PR DESCRIPTION
Upon joining the game, lookup and store the new player's slack info.  Use the players slack 'name' instead of `@name` whereever slackify is used